### PR TITLE
Add fixes for building rt-tests image

### DIFF
--- a/hack/build_images
+++ b/hack/build_images
@@ -40,8 +40,7 @@ build_image() {
         CLEAN_TAG="${CLEAN_TAG}.${PLATFORM}"
     fi
 
-    podman image exists $IMAGE:$CLEAN_TAG
-    if [ $? -eq 0 ] && [ ! "$FORCE" = true ]; then
+    if $(podman image exists $IMAGE:$CLEAN_TAG) && [ ! "$FORCE" = true ]; then
         info "Skipping existing image $IMAGE:$CLEAN_TAG (use '-f' to override)"
     else
         info "Building image $IMAGE:$CLEAN_TAG"
@@ -86,7 +85,9 @@ fi
 podman login ${REGISTRY}
 
 # oai-build-base is a common dependency; ensure it's always included first
-IMAGES="oai-build-base ${IMAGES/oai-build-base/}"
+if [[ "$IMAGES" != "rt-tests" ]]; then
+    IMAGES="oai-build-base ${IMAGES/oai-build-base/}"
+fi
 
 # build all specified images
 for i in $IMAGES; do
@@ -96,7 +97,7 @@ for i in $IMAGES; do
     # if no git_tag specified, grep default from Dockerfile
     if [ "$IMG" = "$TAG" ]; then
         if [ -f images/$IMG/Dockerfile.rh${PLATFORM} ]; then
-            TAG=$(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile.rh${PLATFORM})
+            TAG=$($(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile.rh${PLATFORM}) || echo "latest")
         else
             TAG=$(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile)
         fi

--- a/images/rt-tests/Dockerfile.rhel7
+++ b/images/rt-tests/Dockerfile.rhel7
@@ -5,7 +5,7 @@ RUN REPOLIST=rhel-7-server-rt-rpms \
     PKGLIST="rt-tests rteval procps-ng" \
     && yum -y install --enablerepo ${REPOLIST} ${PKGLIST} \
     && yum -y clean all \
-    && rm -rf /var/cahce/yum
+    && rm -rf /var/cache/yum
 
 USER 0
 ENV APP_ROOT=/opt/rt-tests HOME=${APP_ROOT} PATH=${APP_ROOT}:${PATH}


### PR DESCRIPTION
When building the rt-tests images, some failures
    appeared:
    - error handling not done properly. There are cases
    where commands return exit code 1, that are valid,
    but were causing script to exit. Do a proper
    management of those errors.
    - add special case for rt-tests, that do not need
    the building of oai-base, that is long and heavy
    - fix typo in rt-tests Dockerfile
