### PR TITLE
Add logging to rt tests

### DIFF
--- a/images/rt-tests/Dockerfile.rhel7
+++ b/images/rt-tests/Dockerfile.rhel7
@@ -14,5 +14,5 @@ WORKDIR ${APP_ROOT}
 ENV DURATION=1m
 ENV CORE_LIST=1
 
-CMD ["-c", "taskset -c ${CORE_LIST} rteval -v -d ${DURATION} --loads-cpulist=${CORE_LIST} --measurement-cpulist=${CORE_LIST}"]
+CMD ["-c", "taskset -c ${CORE_LIST} rteval -L -v -d ${DURATION} --loads-cpulist=${CORE_LIST} --measurement-cpulist=${CORE_LIST}"]
 ENTRYPOINT ["/bin/bash"]

--- a/images/rt-tests/Dockerfile.rhel8
+++ b/images/rt-tests/Dockerfile.rhel8
@@ -14,5 +14,5 @@ WORKDIR ${APP_ROOT}
 ENV DURATION=1m
 ENV CORE_LIST=1
 
-CMD ["-c", "taskset -c ${CORE_LIST} rteval -v -d ${DURATION} --loads-cpulist=${CORE_LIST} --measurement-cpulist=${CORE_LIST}"]
+CMD ["-c", "taskset -c ${CORE_LIST} rteval -L -v -d ${DURATION} --loads-cpulist=${CORE_LIST} --measurement-cpulist=${CORE_LIST}"]
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
When running on kubernetes capturing the output
of the command is difficult. Enable the logging
option so it will generate logs on /opt/rt-tests,
and we then can map a volume there.