### PR TITLE
Build support for CentOS and Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ git clone http://github.com/OPENAIRINTERFACE/openair-k8s
 cd openair-k8s
 ```
 
+#### Ubuntu
+
+Follow this [guide](https://computingforgeeks.com/how-to-install-podman-on-ubuntu/) to install `podman`.
+
 ### Building
 To build all OAI component images:
 ```sh

--- a/hack/build_images
+++ b/hack/build_images
@@ -2,16 +2,19 @@
 
 source /etc/os-release
 PLATFORM=${PLATFORM:-${ID#rh*}${VERSION_ID%.*}}
-DOCKERFILE_SUFIX=rh${PLATFORM}
+
+if [[ ${PLATFORM} == "rh"* ]]; then
+  DOCKERFILE_SUFIX=rh${PLATFORM}
+else
+  PLATFORM="centos8"
+  DOCKERFILE_SUFIX=${PLATFORM}
+fi
+
 KERNEL_VERSION=${KERNEL_VERSION:-$(uname -r)}
 KERNEL_VERSION=${KERNEL_VERSION%*.x86_64}
 REGISTRY=${REGISTRY:-registry.redhat.io}
 BUILD_ARGS=${BUILD_ARGS:-"--no-cache"}
 IMAGES=$(find images -type f -name Dockerfile* | sed 's|images/||g' | sed 's|/Dockerfile[a-z0-9.]*||g' | sort | uniq | xargs)
-
-if [[ $PLATFORM == *"centos"* ]]; then
-  DOCKERFILE_SUFIX=${PLATFORM}
-fi
 
 info() {
     local MESSAGE=$1
@@ -86,7 +89,7 @@ if [ $# -ne 0 ]; then
   IMAGES=$*
 fi
 
-if [[ $PLATFORM != *"centos"* ]]; then
+if [[ ${PLATFORM} == "rh"* ]]; then
   podman login ${REGISTRY}
 fi
 

--- a/hack/build_images
+++ b/hack/build_images
@@ -1,13 +1,19 @@
 #!/bin/bash
 
-source /etc/os-release
-PLATFORM=${PLATFORM:-${ID#rh*}${VERSION_ID%.*}}
+if [[ -f /etc/os-release ]]; then
+    source /etc/os-release
+    PLATFORM=${PLATFORM:-${ID#rh*}${VERSION_ID%.*}}
+fi
 
 if [[ ${PLATFORM} == "rh"* ]]; then
   DOCKERFILE_SUFIX=rh${PLATFORM}
 else
   PLATFORM="centos8"
   DOCKERFILE_SUFIX=${PLATFORM}
+fi
+
+if hash podman 2>/dev/null; then
+    USE_PODMAN=true
 fi
 
 KERNEL_VERSION=${KERNEL_VERSION:-$(uname -r)}
@@ -37,7 +43,7 @@ available images:
 build_image_podman() {
     local IMAGE=$1
     local TAG=$2
-    local CLEAN_TAG=$(echo $TAG | sed -r 's/^v([0-9])/\1/')
+    local CLEAN_TAG=$(echo $TAG | sed 's/^v\([0-9]\)/\1/')
     echo "Building images using - Podman"
     # Default to building from Dockerfile. If there's a platform-specific Dockerfile
     # use that instead and append the platform name to the image tag.
@@ -67,7 +73,7 @@ build_image_podman() {
 build_image_docker() {
     local IMAGE=$1
     local TAG=$2
-    local CLEAN_TAG=$(echo $TAG | sed -r 's/^v([0-9])/\1/')
+    local CLEAN_TAG=$(echo $TAG | sed 's/^v\([0-9]\)/\1/')
 
     echo "Building images using - Docker"
     # Default to building from Dockerfile. If there's a platform-specific Dockerfile
@@ -130,15 +136,15 @@ for i in $IMAGES; do
     # if no git_tag specified, grep default from Dockerfile
     if [ "$IMG" = "$TAG" ]; then
         if [ -f images/$IMG/Dockerfile.${DOCKERFILE_SUFIX} ]; then
-            TAG=$(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile.${DOCKERFILE_SUFIX} || echo "latest")
+            TAG=$(sed -n "s/ARG GIT_TAG=\(.*\)/\1/p" images/$IMG/Dockerfile.${DOCKERFILE_SUFIX} || echo "latest")
         else
-            TAG=$(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile || echo "latest")
+            TAG=$(sed -n "s/ARG GIT_TAG=\(.*\)/\1/p" images/$IMG/Dockerfile || echo "latest")
         fi
     fi
     # decide whether or not to use docker or podman
-    if [[ -z $USE_DOCKER ]]; then
-        build_image_podman $IMG $TAG
-    else
+    if [[ -z $USE_PODMAN ]]; then
         build_image_docker $IMG $TAG
+    else
+        build_image_podman $IMG $TAG
     fi
 done

--- a/hack/build_images
+++ b/hack/build_images
@@ -34,11 +34,11 @@ available images:
     exit 1
 }
 
-build_image() {
+build_image_podman() {
     local IMAGE=$1
     local TAG=$2
     local CLEAN_TAG=$(echo $TAG | sed -r 's/^v([0-9])/\1/')
-
+    echo "Building images using - Podman"
     # Default to building from Dockerfile. If there's a platform-specific Dockerfile
     # use that instead and append the platform name to the image tag.
     DOCKERFILE="Dockerfile"
@@ -62,6 +62,33 @@ build_image() {
             -t $IMAGE:$CLEAN_TAG \
             images/$IMAGE
     fi
+}
+
+build_image_docker() {
+    local IMAGE=$1
+    local TAG=$2
+    local CLEAN_TAG=$(echo $TAG | sed -r 's/^v([0-9])/\1/')
+
+    echo "Building images using - Docker"
+    # Default to building from Dockerfile. If there's a platform-specific Dockerfile
+    # use that instead and append the platform name to the image tag.
+    DOCKERFILE="Dockerfile"
+    if [ -f images/$IMAGE/Dockerfile.${DOCKERFILE_SUFIX} ]; then
+        DOCKERFILE="Dockerfile.${DOCKERFILE_SUFIX}"
+        CLEAN_TAG="${CLEAN_TAG}.${PLATFORM}"
+    fi
+
+    info "Building image $IMAGE:$CLEAN_TAG"
+
+    docker build \
+        --network=host \
+        $BUILD_ARGS \
+        --build-arg GIT_TAG=$TAG \
+        --build-arg KERNEL_VERSION=$KERNEL_VERSION \
+        --build-arg EURECOM_PROXY=$PROXY \
+        -f images/$IMAGE/$DOCKERFILE \
+        -t $IMAGE:$CLEAN_TAG \
+        images/$IMAGE
 }
 
 # parse command line args
@@ -108,5 +135,10 @@ for i in $IMAGES; do
             TAG=$(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile || echo "latest")
         fi
     fi
-    build_image $IMG $TAG
+    # decide whether or not to use docker or podman
+    if [[ -z $USE_DOCKER ]]; then
+        build_image_podman $IMG $TAG
+    else
+        build_image_docker $IMG $TAG
+    fi
 done

--- a/hack/build_images
+++ b/hack/build_images
@@ -2,11 +2,16 @@
 
 source /etc/os-release
 PLATFORM=${PLATFORM:-${ID#rh*}${VERSION_ID%.*}}
+DOCKERFILE_SUFIX=rh${PLATFORM}
 KERNEL_VERSION=${KERNEL_VERSION:-$(uname -r)}
 KERNEL_VERSION=${KERNEL_VERSION%*.x86_64}
 REGISTRY=${REGISTRY:-registry.redhat.io}
 BUILD_ARGS=${BUILD_ARGS:-"--no-cache"}
 IMAGES=$(find images -type f -name Dockerfile* | sed 's|images/||g' | sed 's|/Dockerfile[a-z0-9.]*||g' | sort | uniq | xargs)
+
+if [[ $PLATFORM == *"centos"* ]]; then
+  DOCKERFILE_SUFIX=${PLATFORM}
+fi
 
 info() {
     local MESSAGE=$1
@@ -34,8 +39,8 @@ build_image() {
     # Default to building from Dockerfile. If there's a platform-specific Dockerfile
     # use that instead and append the platform name to the image tag.
     DOCKERFILE="Dockerfile"
-    if [ -f images/$IMAGE/Dockerfile.rh${PLATFORM} ]; then
-        DOCKERFILE="Dockerfile.rh${PLATFORM}"
+    if [ -f images/$IMAGE/Dockerfile.${DOCKERFILE_SUFIX} ]; then
+        DOCKERFILE="Dockerfile.${DOCKERFILE_SUFIX}"
         CLEAN_TAG="${CLEAN_TAG}.${PLATFORM}"
     fi
 
@@ -81,7 +86,9 @@ if [ $# -ne 0 ]; then
   IMAGES=$*
 fi
 
-podman login ${REGISTRY}
+if [[ $PLATFORM != *"centos"* ]]; then
+  podman login ${REGISTRY}
+fi
 
 IMAGES="oai-build-base ${IMAGES/oai-build-base/}"
 
@@ -92,8 +99,8 @@ for i in $IMAGES; do
     TAG=${i#*:}
     # if no git_tag specified, grep default from Dockerfile
     if [ "$IMG" = "$TAG" ]; then
-        if [ -f images/$IMG/Dockerfile.rh${PLATFORM} ]; then
-            TAG=$(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile.rh${PLATFORM} || echo "latest")
+        if [ -f images/$IMG/Dockerfile.${DOCKERFILE_SUFIX} ]; then
+            TAG=$(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile.${DOCKERFILE_SUFIX} || echo "latest")
         else
             TAG=$(grep -oP "ARG GIT_TAG=\K[a-zA-Z0-9.-]+" images/$IMG/Dockerfile || echo "latest")
         fi

--- a/images/oai-build-base/Dockerfile.centos8
+++ b/images/oai-build-base/Dockerfile.centos8
@@ -47,6 +47,7 @@ RUN yum -y install --enablerepo="PowerTools" \
         lz4-devel \
         mariadb-devel \
         nettle-devel \
+        numactl-devel \
         openssh-clients \
         openssh-server \
         openssl \

--- a/images/oai-build-base/Dockerfile.centos8
+++ b/images/oai-build-base/Dockerfile.centos8
@@ -2,7 +2,7 @@ FROM centos:8
 
 ARG GIT_TAG=latest
 LABEL name="oai-build-base" \
-      version="${GIT_TAG}.el8" \
+      version="${GIT_TAG}.centos8" \
       io.k8s.description="Image containing all build dependencies for openairinterface5g and openair-cn."
 
 WORKDIR /root
@@ -16,7 +16,9 @@ RUN yum -y install --enablerepo="PowerTools" \
         bzip2-devel \
         check \
         check-devel \
+        diffutils \
         elfutils-libelf-devel \
+        file \
         gflags-devel \
         glog-devel \
         gmp-devel \
@@ -67,11 +69,7 @@ RUN yum -y install --enablerepo="PowerTools" \
     && rm -rf /var/cache/yum \
     && pip2 install --user mako pexpect
 
-# RUN git clone https://gist.github.com/2190472.git /opt/ssh
-
-RUN if [ "$EURECOM_PROXY" == true ]; then git config --global http.proxy http://:@proxy.eurecom.fr:8080; fi
-
-# build packages not present in RHEL/EPEL repos
+# build packages not present in CentOS/EPEL repos
 COPY patches patches/
 COPY scripts scripts/
 RUN scripts/build_missing_packages

--- a/images/oai-build-base/Dockerfile.centos8
+++ b/images/oai-build-base/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM centos:8
 
 ARG GIT_TAG=latest

--- a/images/oai-build-base/Dockerfile.centos8
+++ b/images/oai-build-base/Dockerfile.centos8
@@ -1,0 +1,77 @@
+FROM centos:8
+
+ARG GIT_TAG=latest
+LABEL name="oai-build-base" \
+      version="${GIT_TAG}.el8" \
+      io.k8s.description="Image containing all build dependencies for openairinterface5g and openair-cn."
+
+WORKDIR /root
+RUN yum -y install --enablerepo="PowerTools" \
+        git make cmake gcc gcc-c++ autoconf automake bc bison flex libtool patch \
+        atlas-devel \
+        blas \
+        blas-devel \
+        boost \
+        boost-devel \
+        bzip2-devel \
+        check \
+        check-devel \
+        elfutils-libelf-devel \
+        gflags-devel \
+        glog-devel \
+        gmp-devel \
+        gnutls-devel \
+        guile-devel \
+        kernel-devel \
+        kernel-headers \
+        lapack \
+        lapack-devel \
+        libasan \
+        libconfig-devel \
+        libevent-devel \
+        libffi-devel \
+        libgcrypt-devel \
+        libidn-devel \
+        libidn2-devel  \
+        libtool \
+        libusb-devel \
+        libusbx-devel \
+        libxml2-devel \
+        libXpm-devel \
+        libxslt-devel \
+        libyaml-devel \
+        lksctp-tools \
+        lksctp-tools-devel \
+        lz4-devel \
+        mariadb-devel \
+        nettle-devel \
+        openssh-clients \
+        openssh-server \
+        openssl \
+        openssl-devel \
+        pkgconfig \
+        protobuf \
+        protobuf-c \
+        protobuf-c-compiler \
+        protobuf-c-devel \
+        psmisc \
+        python2 \
+        python2-docutils \
+        python2-requests \
+        vim-common \
+        xz-devel \
+        zlib-devel \
+    && yum install -y http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/x/xforms-1.2.4-5.el7.x86_64.rpm \
+    && yum install -y http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/x/xforms-devel-1.2.4-5.el7.x86_64.rpm \
+    && yum clean all -y \
+    && rm -rf /var/cache/yum \
+    && pip2 install --user mako pexpect
+
+# RUN git clone https://gist.github.com/2190472.git /opt/ssh
+
+RUN if [ "$EURECOM_PROXY" == true ]; then git config --global http.proxy http://:@proxy.eurecom.fr:8080; fi
+
+# build packages not present in RHEL/EPEL repos
+COPY patches patches/
+COPY scripts scripts/
+RUN scripts/build_missing_packages

--- a/images/oai-enb/Dockerfile.centos8
+++ b/images/oai-enb/Dockerfile.centos8
@@ -1,5 +1,4 @@
-ARG REGISTRY=localhost
-FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=v1.1.1
 
@@ -20,10 +19,7 @@ RUN cd openairinterface5g/cmake_targets \
 FROM centos:8
 LABEL name="oai-enb" \
       version="$GIT_TAG" \
-      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
-      io.k8s.description="openairinterface5g eNB $GIT_TAG." \
-      io.openshift.tags="oai,enb" \
-      io.openshift.non-scalable="true"
+      io.k8s.description="openairinterface5g eNB $GIT_TAG."
 
 RUN REPOLIST="PowerTools" \
     PKGLIST="boost libconfig lksctp-tools protobuf-c iproute iputils procps-ng bind-utils" \

--- a/images/oai-enb/Dockerfile.centos8
+++ b/images/oai-enb/Dockerfile.centos8
@@ -1,0 +1,64 @@
+ARG REGISTRY=localhost
+FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+
+ARG GIT_TAG=v1.1.1
+
+WORKDIR /root
+
+RUN if [ "$EURECOM_PROXY" == true ]; then git config --global http.proxy http://:@proxy.eurecom.fr:8080; fi
+
+RUN git clone --depth=1 --branch=$GIT_TAG https://gitlab.eurecom.fr/oai/openairinterface5g.git
+COPY patches patches/
+RUN patch -p1 -d openairinterface5g < patches/disable_building_nasmesh_and_rbtool.patch \
+    && patch -p1 -d openairinterface5g < patches/disable_sched_fifo_fail_exits.patch
+RUN cd openairinterface5g/cmake_targets \
+    && ln -sf /usr/local/bin/asn1c_oai /usr/local/bin/asn1c \
+    && ln -sf /usr/local/share/asn1c_oai /usr/local/share/asn1c \
+    && ./build_oai -c --eNB -w USRP --verbose-compile
+
+
+FROM centos:8
+LABEL name="oai-enb" \
+      version="$GIT_TAG" \
+      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
+      io.k8s.description="openairinterface5g eNB $GIT_TAG." \
+      io.openshift.tags="oai,enb" \
+      io.openshift.non-scalable="true"
+
+RUN REPOLIST="PowerTools" \
+    PKGLIST="boost libconfig lksctp-tools protobuf-c iproute iputils procps-ng bind-utils" \
+    # && yum -y upgrade-minimal --setopt=tsflags=nodocs --security --sec-severity=Critical --sec-severity=Important && \
+    && yum -y install --enablerepo ${REPOLIST} --setopt=tsflag=nodocs ${PKGLIST} \
+    && yum -y install http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/x/xforms-1.2.4-5.el7.x86_64.rpm \
+    && yum -y clean all \
+    && rm -rf /var/cache/yum
+
+ENV APP_ROOT=/opt/oai-enb
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/lte-softmodem ${APP_ROOT}/bin/
+COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/*.so* /lib64
+COPY --from=builder /usr/local/lib64 /lib64
+COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin
+COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd
+RUN cd /lib64 \
+    && ln -sf liboai_eth_transpro.so liboai_transpro.so \
+    && ln -sf liboai_usrpdevif.so liboai_device.so \
+    && ln -sf libuhd.so.3.13 libuhd.so.3 \
+    && ln -sf libuhd.so.3 libuhd.so
+COPY scripts ${APP_ROOT}/bin/
+COPY configs ${APP_ROOT}/etc/
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+USER 10001
+WORKDIR ${APP_ROOT}
+
+EXPOSE 2152/udp  # S1U, GTP/UDP
+EXPOSE 22100/tcp # ?
+EXPOSE 36412/udp # S1C, SCTP/UDP
+EXPOSE 36422/udp # X2C, SCTP/UDP
+EXPOSE 50000/udp # IF5 / ORI (control)
+EXPOSE 50001/udp # IF5 / ECPRI (data)
+
+CMD ["/opt/oai-enb/bin/lte-softmodem", "-O", "/opt/oai-enb/etc/enb.conf"]
+ENTRYPOINT ["/opt/oai-enb/bin/entrypoint.sh"]

--- a/images/oai-enb/Dockerfile.centos8
+++ b/images/oai-enb/Dockerfile.centos8
@@ -32,10 +32,10 @@ RUN REPOLIST="PowerTools" \
 ENV APP_ROOT=/opt/oai-enb
 ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
 COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/lte-softmodem ${APP_ROOT}/bin/
-COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/*.so* /lib64
-COPY --from=builder /usr/local/lib64 /lib64
-COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin
-COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd
+COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/*.so* /lib64/
+COPY --from=builder /usr/local/lib64 /lib64/
+COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin/
+COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd/
 RUN cd /lib64 \
     && ln -sf liboai_eth_transpro.so liboai_transpro.so \
     && ln -sf liboai_usrpdevif.so liboai_device.so \

--- a/images/oai-enb/Dockerfile.centos8
+++ b/images/oai-enb/Dockerfile.centos8
@@ -49,12 +49,18 @@ RUN chmod -R u+x ${APP_ROOT} && \
 USER 10001
 WORKDIR ${APP_ROOT}
 
-EXPOSE 2152/udp  # S1U, GTP/UDP
-EXPOSE 22100/tcp # ?
-EXPOSE 36412/udp # S1C, SCTP/UDP
-EXPOSE 36422/udp # X2C, SCTP/UDP
-EXPOSE 50000/udp # IF5 / ORI (control)
-EXPOSE 50001/udp # IF5 / ECPRI (data)
+# S1U, GTP/UDP
+EXPOSE 2152/udp
+# ?
+EXPOSE 22100/tcp
+# S1C, SCTP/UDP
+EXPOSE 36412/udp
+# X2C, SCTP/UDP
+EXPOSE 36422/udp
+# IF5 / ORI (control)
+EXPOSE 50000/udp
+# IF5 / ECPRI (data)
+EXPOSE 50001/udp
 
 CMD ["/opt/oai-enb/bin/lte-softmodem", "-O", "/opt/oai-enb/etc/enb.conf"]
 ENTRYPOINT ["/opt/oai-enb/bin/entrypoint.sh"]

--- a/images/oai-enb/Dockerfile.centos8
+++ b/images/oai-enb/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=v1.1.1

--- a/images/oai-gnb/Dockerfile.centos8
+++ b/images/oai-gnb/Dockerfile.centos8
@@ -31,10 +31,10 @@ RUN REPOLIST="PowerTools" \
 ENV APP_ROOT=/opt/oai-gnb
 ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
 COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/nr-softmodem ${APP_ROOT}/bin/
-COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/*.so* /lib64
-COPY --from=builder /usr/local/lib64 /lib64
-COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin
-COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd
+COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/*.so* /lib64/
+COPY --from=builder /usr/local/lib64 /lib64/
+COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin/
+COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd/
 RUN cd /lib64 \
     && ln -sf liboai_eth_transpro.so liboai_transpro.so \
     && ln -sf liboai_usrpdevif.so liboai_device.so \

--- a/images/oai-gnb/Dockerfile.centos8
+++ b/images/oai-gnb/Dockerfile.centos8
@@ -48,12 +48,18 @@ RUN chmod -R u+x ${APP_ROOT} && \
 USER 10001
 WORKDIR ${APP_ROOT}
 
-EXPOSE 2152/udp  # S1U, GTP/UDP
-EXPOSE 22100/tcp # ?
-EXPOSE 36412/udp # S1C, SCTP/UDP
-EXPOSE 36422/udp # X2C, SCTP/UDP
-EXPOSE 50000/udp # IF5 / ORI (control)
-EXPOSE 50001/udp # IF5 / ECPRI (data)
+# S1U, GTP/UDP
+EXPOSE 2152/udp
+# ?
+EXPOSE 22100/tcp
+# S1C, SCTP/UDP
+EXPOSE 36412/udp
+# X2C, SCTP/UDP
+EXPOSE 36422/udp
+# IF5 / ORI (control)
+EXPOSE 50000/udp
+# IF5 / ECPRI (data)
+EXPOSE 50001/udp
 
 CMD ["/opt/oai-gnb/bin/nr-softmodem", "-O", "/opt/oai-gnb/etc/gnb.conf"]
 ENTRYPOINT ["/opt/oai-gnb/bin/entrypoint.sh"]

--- a/images/oai-gnb/Dockerfile.centos8
+++ b/images/oai-gnb/Dockerfile.centos8
@@ -1,5 +1,4 @@
-ARG REGISTRY=localhost
-FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-nr
 
@@ -19,10 +18,7 @@ RUN cd openairinterface5g/cmake_targets \
 FROM centos:8
 LABEL name="oai-gnb" \
       version="$GIT_TAG" \
-      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
-      io.k8s.description="openairinterface5g gNB $GIT_TAG." \
-      io.openshift.tags="oai,gnb" \
-      io.openshift.non-scalable="true"
+      io.k8s.description="openairinterface5g gNB $GIT_TAG."
 
 RUN REPOLIST="PowerTools" \
     && PKGLIST="atlas blas boost lapack libconfig libusb libusbx lksctp-tools protobuf-c iproute iputils procps-ng bind-utils" \

--- a/images/oai-gnb/Dockerfile.centos8
+++ b/images/oai-gnb/Dockerfile.centos8
@@ -1,0 +1,63 @@
+ARG REGISTRY=localhost
+FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+
+ARG GIT_TAG=develop-nr
+
+WORKDIR /root
+
+RUN if [ "$EURECOM_PROXY" == true ]; then git config --global http.proxy http://:@proxy.eurecom.fr:8080; fi
+
+RUN git clone --depth=1 --branch=$GIT_TAG https://gitlab.eurecom.fr/oai/openairinterface5g.git
+COPY patches patches/
+RUN patch -p1 -d openairinterface5g < patches/disable_building_nasmesh_rbtools_ue_ip.patch
+RUN cd openairinterface5g/cmake_targets \
+    && ln -sf /usr/local/bin/asn1c_oai /usr/local/bin/asn1c \
+    && ln -sf /usr/local/share/asn1c_oai /usr/local/share/asn1c \
+    && ./build_oai --gNB -w USRP --verbose-compile
+
+
+FROM centos:8
+LABEL name="oai-gnb" \
+      version="$GIT_TAG" \
+      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
+      io.k8s.description="openairinterface5g gNB $GIT_TAG." \
+      io.openshift.tags="oai,gnb" \
+      io.openshift.non-scalable="true"
+
+RUN REPOLIST="PowerTools" \
+    && PKGLIST="atlas blas boost lapack libconfig libusb libusbx lksctp-tools protobuf-c iproute iputils procps-ng bind-utils" \
+    # && yum -y upgrade-minimal --setopt=tsflags=nodocs --security --sec-severity=Critical --sec-severity=Important \
+    && yum -y install --enablerepo ${REPOLIST} --setopt=tsflag=nodocs ${PKGLIST} \
+    && yum install -y http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/x/xforms-1.2.4-5.el7.x86_64.rpm \
+    && yum -y clean all \
+    && rm -rf /var/cache/yum
+
+ENV APP_ROOT=/opt/oai-gnb
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/nr-softmodem ${APP_ROOT}/bin/
+COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/*.so* /lib64
+COPY --from=builder /usr/local/lib64 /lib64
+COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin
+COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd
+RUN cd /lib64 \
+    && ln -sf liboai_eth_transpro.so liboai_transpro.so \
+    && ln -sf liboai_usrpdevif.so liboai_device.so \
+    && ln -sf libuhd.so.3.13 libuhd.so.3 \
+    && ln -sf libuhd.so.3 libuhd.so
+COPY scripts ${APP_ROOT}/bin/
+COPY configs ${APP_ROOT}/etc/
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+USER 10001
+WORKDIR ${APP_ROOT}
+
+EXPOSE 2152/udp  # S1U, GTP/UDP
+EXPOSE 22100/tcp # ?
+EXPOSE 36412/udp # S1C, SCTP/UDP
+EXPOSE 36422/udp # X2C, SCTP/UDP
+EXPOSE 50000/udp # IF5 / ORI (control)
+EXPOSE 50001/udp # IF5 / ECPRI (data)
+
+CMD ["/opt/oai-gnb/bin/nr-softmodem", "-O", "/opt/oai-gnb/etc/gnb.conf"]
+ENTRYPOINT ["/opt/oai-gnb/bin/entrypoint.sh"]

--- a/images/oai-gnb/Dockerfile.centos8
+++ b/images/oai-gnb/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-nr

--- a/images/oai-hss/Dockerfile.centos8
+++ b/images/oai-hss/Dockerfile.centos8
@@ -1,5 +1,4 @@
-ARG REGISTRY=localhost
-FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-vco3
 
@@ -21,11 +20,7 @@ RUN cd openair-cn/scripts \
 FROM centos:8
 LABEL name="oai-hss" \
       version="$GIT_TAG" \
-      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
-      io.k8s.description="openair-cn HSS $GIT_TAG." \
-      io.openshift.tags="oai,hss" \
-      io.openshift.non-scalable="true" \
-      io.openshift.wants="mariadb"
+      io.k8s.description="openair-cn HSS $GIT_TAG."
 
 RUN REPOLIST=PowerTools \
     PKGLIST="libconfig libidn mariadb-devel lksctp-tools mysql iproute iputils procps-ng bind-utils" && \

--- a/images/oai-hss/Dockerfile.centos8
+++ b/images/oai-hss/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-vco3

--- a/images/oai-hss/Dockerfile.centos8
+++ b/images/oai-hss/Dockerfile.centos8
@@ -1,0 +1,58 @@
+ARG REGISTRY=localhost
+FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+
+ARG GIT_TAG=develop-vco3
+
+WORKDIR /root
+
+RUN git clone --depth=1 --branch=$GIT_TAG https://github.com/OPENAIRINTERFACE/openair-cn.git
+COPY patches patches/
+RUN patch -p1 -d openair-cn < patches/enable_sudo-less_build.patch \
+    && patch -p1 -d openair-cn < patches/disable_distro_check_and_rpm_install.patch \
+    && patch -p1 -d openair-cn < patches/fix_libpistache_lib_path.patch
+RUN cd openair-cn/scripts \
+    && ln -sf /usr/local/bin/asn1c_cn /usr/local/bin/asn1c \
+    && ln -sf /usr/local/share/asn1c_cn /usr/local/share/asn1c \
+    && rm -rf /usr/local/lib/freeDiameter /usr/local/lib/libfd* \
+    && OPENAIRCN_DIR=$(dirname $(pwd)) ./build_hss_rel14 --check-installed-software --force \
+    && OPENAIRCN_DIR=$(dirname $(pwd)) ./build_hss_rel14 -v
+
+
+FROM centos:8
+LABEL name="oai-hss" \
+      version="$GIT_TAG" \
+      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
+      io.k8s.description="openair-cn HSS $GIT_TAG." \
+      io.openshift.tags="oai,hss" \
+      io.openshift.non-scalable="true" \
+      io.openshift.wants="mariadb"
+
+RUN REPOLIST=PowerTools \
+    PKGLIST="libconfig libidn mariadb-devel lksctp-tools mysql iproute iputils procps-ng bind-utils" && \
+    # yum -y upgrade-minimal --setopt=tsflags=nodocs --security --sec-severity=Critical --sec-severity=Important && \
+    yum -y install --enablerepo ${REPOLIST} --setopt=tsflag=nodocs ${PKGLIST} && \
+    yum -y clean all
+
+ENV APP_ROOT=/opt/oai-hss
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+
+COPY --from=builder /root/openair-cn/build/hss_rel14/bin/hss ${APP_ROOT}/bin/oai_hss
+COPY --from=builder /usr/local/lib/libfd* /lib64
+COPY --from=builder /usr/local/lib/freeDiameter/* /usr/local/lib/freeDiameter/
+COPY --from=builder /usr/local/lib64/libcassandra* /lib64
+COPY --from=builder /usr/local/lib64/libuv.so /lib64
+COPY scripts ${APP_ROOT}/bin/
+COPY configs ${APP_ROOT}/etc/
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+USER 10001
+WORKDIR ${APP_ROOT}
+
+# expose ports configured in hss_fd.conf
+EXPOSE 9042/tcp 5868/tcp 9080/tcp 9081/tcp
+
+VOLUME ["${APP_ROOT}/certs"]
+
+CMD ["/opt/oai-hss/bin/oai_hss", "-j", "/opt/oai-hss/etc/hss_rel14.json"]
+ENTRYPOINT ["/opt/oai-hss/bin/entrypoint.sh"]

--- a/images/oai-hss/Dockerfile.centos8
+++ b/images/oai-hss/Dockerfile.centos8
@@ -31,11 +31,11 @@ RUN REPOLIST=PowerTools \
 ENV APP_ROOT=/opt/oai-hss
 ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
 
-COPY --from=builder /root/openair-cn/build/hss_rel14/bin/hss ${APP_ROOT}/bin/oai_hss
-COPY --from=builder /usr/local/lib/libfd* /lib64
+COPY --from=builder /root/openair-cn/build/hss_rel14/bin/hss ${APP_ROOT}/bin/oai_hss/
+COPY --from=builder /usr/local/lib/libfd* /lib64/
 COPY --from=builder /usr/local/lib/freeDiameter/* /usr/local/lib/freeDiameter/
-COPY --from=builder /usr/local/lib64/libcassandra* /lib64
-COPY --from=builder /usr/local/lib64/libuv.so /lib64
+COPY --from=builder /usr/local/lib64/libcassandra* /lib64/
+COPY --from=builder /usr/local/lib64/libuv.so /lib64/
 COPY scripts ${APP_ROOT}/bin/
 COPY configs ${APP_ROOT}/etc/
 RUN chmod -R u+x ${APP_ROOT} && \

--- a/images/oai-mme/Dockerfile.centos8
+++ b/images/oai-mme/Dockerfile.centos8
@@ -30,9 +30,9 @@ RUN REPOLIST=PowerTools \
 ENV APP_ROOT=/opt/oai-mme
 ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
 COPY --from=builder /root/openair-cn/build/mme/build/mme ${APP_ROOT}/bin/
-COPY --from=builder /usr/local/lib/libfd* /lib64
+COPY --from=builder /usr/local/lib/libfd* /lib64/
 COPY --from=builder /usr/local/lib/freeDiameter/* /usr/local/lib/freeDiameter/
-COPY --from=builder /usr/local/lib/liblfds* /usr/lib64
+COPY --from=builder /usr/local/lib/liblfds* /usr/lib64/
 COPY scripts ${APP_ROOT}/bin/
 COPY configs ${APP_ROOT}/etc/
 RUN chmod -R u+x ${APP_ROOT} && \

--- a/images/oai-mme/Dockerfile.centos8
+++ b/images/oai-mme/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-vco3

--- a/images/oai-mme/Dockerfile.centos8
+++ b/images/oai-mme/Dockerfile.centos8
@@ -1,5 +1,4 @@
-ARG REGISTRY=localhost
-FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-vco3
 
@@ -20,10 +19,7 @@ RUN cd openair-cn/scripts \
 FROM centos:8
 LABEL name="oai-mme" \
       version="$GIT_TAG" \
-      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
-      io.k8s.description="openair-cn MME $GIT_TAG." \
-      io.openshift.tags="oai,mme" \
-      io.openshift.non-scalable="true"
+      io.k8s.description="openair-cn MME $GIT_TAG."
 
 RUN REPOLIST=PowerTools \
     PKGLIST="libconfig libasan libidn lksctp-tools iproute iputils procps-ng bind-utils" && \

--- a/images/oai-mme/Dockerfile.centos8
+++ b/images/oai-mme/Dockerfile.centos8
@@ -1,0 +1,54 @@
+ARG REGISTRY=localhost
+FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+
+ARG GIT_TAG=develop-vco3
+
+WORKDIR /root
+
+RUN git clone --depth=1 --branch=$GIT_TAG https://github.com/OPENAIRINTERFACE/openair-cn.git
+COPY patches patches/
+RUN patch -p1 -d openair-cn < patches/enable_sudo-less_build.patch \
+    && patch -p1 -d openair-cn < patches/disable_distro_check_and_rpm_install.patch
+RUN cd openair-cn/scripts \
+    && ln -sf /usr/local/bin/asn1c_cn /usr/local/bin/asn1c \
+    && ln -sf /usr/local/share/asn1c_cn /usr/local/share/asn1c \
+    && rm -rf /usr/local/lib/freeDiameter /usr/local/lib/libfd* \
+    && OPENAIRCN_DIR=$(dirname $(pwd)) ./build_mme --check-installed-software --force \
+    && OPENAIRCN_DIR=$(dirname $(pwd)) ./build_mme -c -v -b Debug
+
+
+FROM centos:8
+LABEL name="oai-mme" \
+      version="$GIT_TAG" \
+      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
+      io.k8s.description="openair-cn MME $GIT_TAG." \
+      io.openshift.tags="oai,mme" \
+      io.openshift.non-scalable="true"
+
+RUN REPOLIST=PowerTools \
+    PKGLIST="libconfig libasan libidn lksctp-tools iproute iputils procps-ng bind-utils" && \
+    # yum -y upgrade-minimal --setopt=tsflags=nodocs --security --sec-severity=Critical --sec-severity=Important && \
+    yum -y install --enablerepo ${REPOLIST} --setopt=tsflag=nodocs ${PKGLIST} && \
+    yum -y clean all
+
+ENV APP_ROOT=/opt/oai-mme
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+COPY --from=builder /root/openair-cn/build/mme/build/mme ${APP_ROOT}/bin/
+COPY --from=builder /usr/local/lib/libfd* /lib64
+COPY --from=builder /usr/local/lib/freeDiameter/* /usr/local/lib/freeDiameter/
+COPY --from=builder /usr/local/lib/liblfds* /usr/lib64
+COPY scripts ${APP_ROOT}/bin/
+COPY configs ${APP_ROOT}/etc/
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+#USER 10001
+WORKDIR ${APP_ROOT}
+
+# expose ports
+EXPOSE 3870/tcp 5870/tcp 2123/udp
+
+VOLUME ["${APP_ROOT}/certs"]
+
+CMD ["/opt/oai-mme/bin/mme", "-c", "/opt/oai-mme/etc/mme.conf"]
+ENTRYPOINT ["/opt/oai-mme/bin/entrypoint.sh"]

--- a/images/oai-nrue/Dockerfile.centos8
+++ b/images/oai-nrue/Dockerfile.centos8
@@ -1,0 +1,62 @@
+ARG REGISTRY=localhost
+FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+
+ARG GIT_TAG=develop-nr
+
+WORKDIR /root
+
+RUN if [ "$EURECOM_PROXY" == true ]; then git config --global http.proxy http://:@proxy.eurecom.fr:8080; fi
+
+RUN git clone --depth=1 --branch=$GIT_TAG https://gitlab.eurecom.fr/oai/openairinterface5g.git
+COPY patches patches/
+RUN patch -p1 -d openairinterface5g < patches/disable_building_nasmesh_rbtools_ue_ip.patch
+RUN cd openairinterface5g/cmake_targets \
+    && ln -sf /usr/local/bin/asn1c_oai /usr/local/bin/asn1c \
+    && ln -sf /usr/local/share/asn1c_oai /usr/local/share/asn1c \
+    && ./build_oai --nrUE -w USRP --verbose-compile
+
+
+FROM centos:8
+LABEL name="oai-nrue" \
+      version="$GIT_TAG" \
+      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
+      io.k8s.description="openairinterface5g nrUE $GIT_TAG." \
+      io.openshift.tags="oai,ue" \
+      io.openshift.non-scalable="true"
+
+RUN REPOLIST="PowerTools" \
+    && PKGLIST="atlas blas boost lapack libconfig libusb libusbx lksctp-tools protobuf-c iproute iputils procps-ng bind-utils" \
+    # && yum -y upgrade-minimal --setopt=tsflags=nodocs --security --sec-severity=Critical --sec-severity=Important \
+    && yum -y install --enablerepo ${REPOLIST} --setopt=tsflag=nodocs ${PKGLIST} \
+    && yum install -y http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/x/xforms-1.2.4-5.el7.x86_64.rpm \
+    && yum -y clean all \
+    && rm -rf /var/cache/yum
+
+ENV APP_ROOT=/opt/oai-nrue
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/nr-uesoftmodem ${APP_ROOT}/bin/
+COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/*.so* /lib64
+COPY --from=builder /usr/local/lib64 /lib64
+COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin
+COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd
+RUN cd /lib64 \
+    && ln -sf liboai_eth_transpro.so liboai_transpro.so \
+    && ln -sf liboai_usrpdevif.so liboai_device.so \
+    && ln -sf libuhd.so.3.13 libuhd.so.3 \
+    && ln -sf libuhd.so.3 libuhd.so
+COPY scripts ${APP_ROOT}/bin/
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+USER 10001
+WORKDIR ${APP_ROOT}
+
+EXPOSE 2152/udp  # S1U, GTP/UDP
+EXPOSE 22100/tcp # ?
+EXPOSE 36412/udp # S1C, SCTP/UDP
+EXPOSE 36422/udp # X2C, SCTP/UDP
+EXPOSE 50000/udp # IF5 / ORI (control)
+EXPOSE 50001/udp # IF5 / ECPRI (data)
+
+CMD ["/opt/oai-gnb/bin/nr-uesoftmodem", "--numerology", "1", "-r", "106", "--phy-test", "-C", "3510000000"]
+ENTRYPOINT ["/opt/oai-gnb/bin/entrypoint.sh"]

--- a/images/oai-nrue/Dockerfile.centos8
+++ b/images/oai-nrue/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-nr

--- a/images/oai-nrue/Dockerfile.centos8
+++ b/images/oai-nrue/Dockerfile.centos8
@@ -31,10 +31,10 @@ RUN REPOLIST="PowerTools" \
 ENV APP_ROOT=/opt/oai-nrue
 ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
 COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/nr-uesoftmodem ${APP_ROOT}/bin/
-COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/*.so* /lib64
-COPY --from=builder /usr/local/lib64 /lib64
-COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin
-COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd
+COPY --from=builder /root/openairinterface5g/cmake_targets/ran_build/build/*.so* /lib64/
+COPY --from=builder /usr/local/lib64 /lib64/
+COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin/
+COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd/
 RUN cd /lib64 \
     && ln -sf liboai_eth_transpro.so liboai_transpro.so \
     && ln -sf liboai_usrpdevif.so liboai_device.so \

--- a/images/oai-nrue/Dockerfile.centos8
+++ b/images/oai-nrue/Dockerfile.centos8
@@ -1,5 +1,4 @@
-ARG REGISTRY=localhost
-FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-nr
 
@@ -19,10 +18,7 @@ RUN cd openairinterface5g/cmake_targets \
 FROM centos:8
 LABEL name="oai-nrue" \
       version="$GIT_TAG" \
-      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
-      io.k8s.description="openairinterface5g nrUE $GIT_TAG." \
-      io.openshift.tags="oai,ue" \
-      io.openshift.non-scalable="true"
+      io.k8s.description="openairinterface5g nrUE $GIT_TAG."
 
 RUN REPOLIST="PowerTools" \
     && PKGLIST="atlas blas boost lapack libconfig libusb libusbx lksctp-tools protobuf-c iproute iputils procps-ng bind-utils" \

--- a/images/oai-nrue/Dockerfile.centos8
+++ b/images/oai-nrue/Dockerfile.centos8
@@ -47,12 +47,18 @@ RUN chmod -R u+x ${APP_ROOT} && \
 USER 10001
 WORKDIR ${APP_ROOT}
 
-EXPOSE 2152/udp  # S1U, GTP/UDP
-EXPOSE 22100/tcp # ?
-EXPOSE 36412/udp # S1C, SCTP/UDP
-EXPOSE 36422/udp # X2C, SCTP/UDP
-EXPOSE 50000/udp # IF5 / ORI (control)
-EXPOSE 50001/udp # IF5 / ECPRI (data)
+# S1U, GTP/UDP
+EXPOSE 2152/udp
+# ?
+EXPOSE 22100/tcp
+# S1C, SCTP/UDP
+EXPOSE 36412/udp
+# X2C, SCTP/UDP
+EXPOSE 36422/udp
+# IF5 / ORI (control)
+EXPOSE 50000/udp
+# IF5 / ECPRI (data)
+EXPOSE 50001/udp
 
 CMD ["/opt/oai-gnb/bin/nr-uesoftmodem", "--numerology", "1", "-r", "106", "--phy-test", "-C", "3510000000"]
 ENTRYPOINT ["/opt/oai-gnb/bin/entrypoint.sh"]

--- a/images/oai-spgwc/Dockerfile.centos8
+++ b/images/oai-spgwc/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-vco3

--- a/images/oai-spgwc/Dockerfile.centos8
+++ b/images/oai-spgwc/Dockerfile.centos8
@@ -1,0 +1,46 @@
+ARG REGISTRY=localhost
+FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+
+ARG GIT_TAG=develop-vco3
+
+WORKDIR /root
+
+RUN git clone --depth=1 --branch=$GIT_TAG https://github.com/OPENAIRINTERFACE/openair-cn-cups.git
+RUN git clone --depth=1 --branch=master https://github.com/gabime/spdlog.git openair-cn-cups/build/ext/spdlog
+COPY patches patches/
+RUN patch -p1 -d openair-cn-cups < patches/enable_sudo-less_build.patch
+RUN cd openair-cn-cups/build/scripts \
+    && ./build_spgwc -c -v -b RelWithDebInfo -j
+
+
+FROM centos:8
+LABEL name="oai-spgwc" \
+      version="$GIT_TAG" \
+      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
+      io.k8s.description="openair-cn-cups S/P-GW-C $GIT_TAG" \
+      io.openshift.tags="oai,spgwc" \
+      io.openshift.non-scalable="true"
+
+RUN REPOLIST=PowerTools \
+    PKGLIST="boost libasan libconfig libevent gflags-devel glog-devel iproute iputils procps-ng bind-utils" && \
+    # yum -y update-minimal --setopt=tsflags=nodocs --security --sec-severity=Important --sec-severity=Critical && \
+    yum -y install --enablerepo ${REPOLIST} --setopt=tsflag=nodocs ${PKGLIST} && \
+    yum -y clean all
+
+ENV APP_ROOT=/opt/oai-spgwc
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+COPY --from=builder /root/openair-cn-cups/build/spgw_c/build/spgwc ${APP_ROOT}/bin/
+COPY scripts ${APP_ROOT}/bin/
+COPY configs ${APP_ROOT}/etc/
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+#USER 10001
+WORKDIR ${APP_ROOT}
+
+# expose ports
+EXPOSE 2123/udp 8805/udp
+
+CMD ["/opt/oai-spgwc/bin/spgwc", "-c", "/opt/oai-spgwc/etc/spgw_c.conf", "-o"]
+ENTRYPOINT ["/opt/oai-spgwc/bin/entrypoint.sh"]
+

--- a/images/oai-spgwc/Dockerfile.centos8
+++ b/images/oai-spgwc/Dockerfile.centos8
@@ -1,5 +1,4 @@
-ARG REGISTRY=localhost
-FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-vco3
 
@@ -16,10 +15,7 @@ RUN cd openair-cn-cups/build/scripts \
 FROM centos:8
 LABEL name="oai-spgwc" \
       version="$GIT_TAG" \
-      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
-      io.k8s.description="openair-cn-cups S/P-GW-C $GIT_TAG" \
-      io.openshift.tags="oai,spgwc" \
-      io.openshift.non-scalable="true"
+      io.k8s.description="openair-cn-cups S/P-GW-C $GIT_TAG"
 
 RUN REPOLIST=PowerTools \
     PKGLIST="boost libasan libconfig libevent gflags-devel glog-devel iproute iputils procps-ng bind-utils" && \

--- a/images/oai-spgwu/Dockerfile.centos8
+++ b/images/oai-spgwu/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-vco3

--- a/images/oai-spgwu/Dockerfile.centos8
+++ b/images/oai-spgwu/Dockerfile.centos8
@@ -1,5 +1,4 @@
-ARG REGISTRY=localhost
-FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=develop-vco3
 
@@ -15,10 +14,7 @@ RUN cd openair-cn-cups/build/scripts \
 FROM centos:8
 LABEL name="oai-spgwu" \
       version="$GIT_TAG" \
-      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
-      io.k8s.description="openair-cn-cups S/P-GW-U $GIT_TAG" \
-      io.openshift.tags="oai,spgwu" \
-      io.openshift.non-scalable="true"
+      io.k8s.description="openair-cn-cups S/P-GW-U $GIT_TAG"
 
 RUN REPOLIST=PowerTools \
     PKGLIST="boost libasan libconfig libevent gflags-devel glog-devel iproute iputils iptables procps-ng bind-utils" && \

--- a/images/oai-spgwu/Dockerfile.centos8
+++ b/images/oai-spgwu/Dockerfile.centos8
@@ -1,0 +1,44 @@
+ARG REGISTRY=localhost
+FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+
+ARG GIT_TAG=develop-vco3
+
+WORKDIR /root
+
+RUN git clone --depth=1 --branch=$GIT_TAG https://github.com/OPENAIRINTERFACE/openair-cn-cups.git
+RUN git clone --depth=1 --branch=master https://github.com/gabime/spdlog.git openair-cn-cups/build/ext/spdlog
+COPY patches patches/
+RUN patch -p1 -d openair-cn-cups < patches/enable_sudo-less_build.patch
+RUN cd openair-cn-cups/build/scripts \
+    && ./build_spgwu -c -v -b RelWithDebInfo -j
+
+FROM centos:8
+LABEL name="oai-spgwu" \
+      version="$GIT_TAG" \
+      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
+      io.k8s.description="openair-cn-cups S/P-GW-U $GIT_TAG" \
+      io.openshift.tags="oai,spgwu" \
+      io.openshift.non-scalable="true"
+
+RUN REPOLIST=PowerTools \
+    PKGLIST="boost libasan libconfig libevent gflags-devel glog-devel iproute iputils iptables procps-ng bind-utils" && \
+    # yum -y update-minimal --setopt=tsflags=nodocs --security --sec-severity=Important --sec-severity=Critical && \
+    yum -y install --enablerepo ${REPOLIST} --setopt=tsflag=nodocs ${PKGLIST} && \
+    yum -y clean all
+
+ENV APP_ROOT=/opt/oai-spgwu
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+COPY --from=builder /root/openair-cn-cups/build/spgw_u/build/spgwu ${APP_ROOT}/bin/
+COPY scripts ${APP_ROOT}/bin/
+COPY configs ${APP_ROOT}/etc/
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+#USER 10001
+WORKDIR ${APP_ROOT}
+
+# expose ports
+EXPOSE 2152/udp 8805/udp
+
+CMD ["/opt/oai-spgwu/bin/spgwu", "-c", "/opt/oai-spgwu/etc/spgw_u.conf", "-o"]
+ENTRYPOINT ["/opt/oai-spgwu/bin/entrypoint.sh"]

--- a/images/oai-ue/Dockerfile.centos8
+++ b/images/oai-ue/Dockerfile.centos8
@@ -1,0 +1,61 @@
+ARG REGISTRY=localhost
+FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+
+ARG GIT_TAG=v1.1.1
+
+WORKDIR /root
+
+RUN if [ "$EURECOM_PROXY" == true ]; then git config --global http.proxy http://:@proxy.eurecom.fr:8080; fi
+RUN git clone --depth=1 --branch=$GIT_TAG https://gitlab.eurecom.fr/oai/openairinterface5g.git
+COPY patches patches/
+RUN patch -p1 -d openairinterface5g < patches/disable_building_nasmesh_and_rbtool.patch \
+    && patch -p1 -d openairinterface5g < patches/el8_support_ue_ip_module.patch
+RUN cd openairinterface5g/cmake_targets \
+    && ln -sf /usr/local/bin/asn1c_oai /usr/local/bin/asn1c \
+    && ln -sf /usr/local/share/asn1c_oai /usr/local/share/asn1c \
+    && ./build_oai -c --UE -w USRP --verbose-compile
+
+
+FROM centos:8
+LABEL name="oai-ue" \
+      version="$GIT_TAG" \
+      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
+      io.k8s.description="openairinterface5g UE $GIT_TAG." \
+      io.openshift.tags="oai,ue" \
+      io.openshift.non-scalable="true"
+
+RUN REPOLIST="PowerTools" \
+    && PKGLIST="atlas blas boost lapack libconfig lksctp-tools protobuf-c iproute iputils procps-ng bind-utils" \
+    # && yum -y upgrade-minimal --setopt=tsflags=nodocs --security --sec-severity=Critical --sec-severity=Important \
+    && yum -y install --enablerepo ${REPOLIST} --setopt=tsflag=nodocs ${PKGLIST} \
+    && yum install -y http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/x/xforms-1.2.4-5.el7.x86_64.rpm \
+    && yum -y clean all \
+    && rm -rf /var/cache/yum
+
+ENV APP_ROOT=/opt/oai-ue
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/lte-uesoftmodem ${APP_ROOT}/bin/
+COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/*.so* /lib64
+COPY --from=builder /usr/local/lib64 /lib64
+COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin
+COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd
+RUN cd /lib64 \
+    && ln -sf liboai_eth_transpro.so liboai_transpro.so \
+    && ln -sf liboai_usrpdevif.so liboai_device.so \
+    && ln -sf libuhd.so.3.13 libuhd.so.3 \
+    && ln -sf libuhd.so.3 libuhd.so
+COPY scripts ${APP_ROOT}/bin/
+COPY configs ${APP_ROOT}/etc/
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+USER 10001
+WORKDIR ${APP_ROOT}
+
+# expose ports from ue.conf
+EXPOSE 50000/udp 50001/udp
+
+CMD ["/opt/oai-ue/bin/lte-uesoftmodem", \
+    "-C", "2680000000", "-r", "25", "--nokrnmod", "1", \
+    "-O", "/opt/oai-ue/etc/ue.conf"]
+ENTRYPOINT ["/opt/oai-ue/bin/entrypoint.sh"]

--- a/images/oai-ue/Dockerfile.centos8
+++ b/images/oai-ue/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=v1.1.1

--- a/images/oai-ue/Dockerfile.centos8
+++ b/images/oai-ue/Dockerfile.centos8
@@ -31,10 +31,10 @@ RUN REPOLIST="PowerTools" \
 ENV APP_ROOT=/opt/oai-ue
 ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
 COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/lte-uesoftmodem ${APP_ROOT}/bin/
-COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/*.so* /lib64
-COPY --from=builder /usr/local/lib64 /lib64
-COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin
-COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd
+COPY --from=builder /root/openairinterface5g/cmake_targets/lte_build_oai/build/*.so* /lib64/
+COPY --from=builder /usr/local/lib64 /lib64/
+COPY --from=builder /usr/local/bin/uhd_* /usr/local/bin/
+COPY --from=builder /usr/local/share/uhd /usr/local/share/uhd/
 RUN cd /lib64 \
     && ln -sf liboai_eth_transpro.so liboai_transpro.so \
     && ln -sf liboai_usrpdevif.so liboai_device.so \

--- a/images/oai-ue/Dockerfile.centos8
+++ b/images/oai-ue/Dockerfile.centos8
@@ -1,5 +1,4 @@
-ARG REGISTRY=localhost
-FROM $REGISTRY/oai-build-base:latest.centos8 AS builder
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=v1.1.1
 
@@ -19,10 +18,7 @@ RUN cd openairinterface5g/cmake_targets \
 FROM centos:8
 LABEL name="oai-ue" \
       version="$GIT_TAG" \
-      maintainer="Frank A. Zdarsky <fzdarsky@redhat.com>" \
-      io.k8s.description="openairinterface5g UE $GIT_TAG." \
-      io.openshift.tags="oai,ue" \
-      io.openshift.non-scalable="true"
+      io.k8s.description="openairinterface5g UE $GIT_TAG."
 
 RUN REPOLIST="PowerTools" \
     && PKGLIST="atlas blas boost lapack libconfig lksctp-tools protobuf-c iproute iputils procps-ng bind-utils" \

--- a/images/rt-tests-cyclictest/Dockerfile.centos8
+++ b/images/rt-tests-cyclictest/Dockerfile.centos8
@@ -1,5 +1,7 @@
 FROM centos:8
 
+ARG GIT_TAG=latest
+
 RUN REPOLIST=PowerTools \
     PKGLIST="rt-tests" \
     && yum -y install --enablerepo ${REPOLIST} ${PKGLIST} \

--- a/images/rt-tests-cyclictest/Dockerfile.centos8
+++ b/images/rt-tests-cyclictest/Dockerfile.centos8
@@ -1,12 +1,13 @@
-FROM centos:8
+FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=latest
 
-RUN REPOLIST=PowerTools \
-    PKGLIST="rt-tests" \
-    && yum -y install --enablerepo ${REPOLIST} ${PKGLIST} \
-    && yum -y clean all \
-    && rm -rf /var/cache/yum
+RUN git clone --depth=1 --branch=stable/v1.0  git://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git
+RUN cd rt-tests && make cyclictest
+
+FROM centos:8
+
+COPY --from=builder /root/rt-tests/cyclictest /usr/local/bin/cyclictest/
 
 ARG CORES=1
 ARG CORE_LIST=2

--- a/images/rt-tests-cyclictest/Dockerfile.centos8
+++ b/images/rt-tests-cyclictest/Dockerfile.centos8
@@ -1,3 +1,18 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM oai-build-base:latest.centos8 AS builder
 
 ARG GIT_TAG=latest

--- a/images/rt-tests-cyclictest/Dockerfile.centos8
+++ b/images/rt-tests-cyclictest/Dockerfile.centos8
@@ -1,0 +1,20 @@
+FROM centos:8
+
+RUN REPOLIST=PowerTools \
+    PKGLIST="rt-tests" \
+    && yum -y install --enablerepo ${REPOLIST} ${PKGLIST} \
+    && yum -y clean all \
+    && rm -rf /var/cache/yum
+
+ARG CORES=1
+ARG CORE_LIST=2
+ARG DURATION=1m
+
+ENV CORES="${CORES}"
+ENV CORE_LIST="${CORE_LIST}"
+ENV DURATION="${DURATION}"
+USER root
+
+ENTRYPOINT ["/bin/bash"]
+CMD ["-c", "taskset -c ${CORE_LIST} cyclictest -q -D ${DURATION} -p 99 -t ${CORES} -h 30 -m -a ${CORE_LIST}"]
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For the time being, the OAI project can be built only on RHEL using Podman.
 
The following PR aims to add support for CentOS as a base OS image and Docker as a container engine.

This is the status so far - 
1. Everything but MME is building successfully.
2. Although the images are building okay, it's still not clear if they also work as expected.
 
In that sense, it'd be really helpful if someone can assist with that! 👍 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.