### PR TITLE
Add default openssl.cnf and script fixes

### DIFF
--- a/hack/clean_oai_on_k8s
+++ b/hack/clean_oai_on_k8s
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NAMESPACE={$NAMESPACE:-oai}
+NAMESPACE=${NAMESPACE:-oai}
 
 info() {
     local MESSAGE=$1

--- a/hack/generate_certs
+++ b/hack/generate_certs
@@ -19,6 +19,7 @@ generate_certs() {
     local FQDN=$1
     local PREFIX=$2
     local DIR=$3
+    local REPO_DIR=$(pwd)
 
     TMP=$(mktemp -d)
     function cleanup {
@@ -29,7 +30,12 @@ generate_certs() {
 
     echo "01" > serial
     touch index.txt index.txt.attr
-    cat /etc/pki/tls/openssl.cnf | sed "s|/etc/pki/CA|${TMP}|" > openssl.cnf
+    if [ -f "/etc/pki/tls/openssl.cnf" ]; then
+        cat /etc/pki/tls/openssl.cnf | sed "s|/etc/pki/CA|${TMP}|" > openssl.cnf
+    else
+        dd if=/dev/urandom of=".rnd" bs=256 count=1
+        cp "${REPO_DIR}/openssl.cnf.default" openssl.cnf
+    fi
 
     info "Creating Root CA certificate for '${FQDN}'"
     openssl req -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 \

--- a/openssl.cnf.default
+++ b/openssl.cnf.default
@@ -1,0 +1,87 @@
+#
+# Example OpenSSL configuration file for use with Let's Encrypt.
+# This is only being used for generation of certificate requests.
+# Modified from a standard example by Parliament Hill Computers Ltd.
+#
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+HOME			= .
+RANDFILE		= ./.rnd
+
+[ req ]
+default_bits		= 2048
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+
+# Stop confirmation prompts. All information is contained below.
+prompt			= no
+
+# The extensions to add to a certificate request - see [ v3_req ]
+req_extensions		= v3_req
+
+[ req_distinguished_name ]
+# Describe the Subject (ie the origanisation).
+# The first 6 below could be shortened to: C ST L O OU CN
+# The short names are what are shown when the certificate is displayed.
+# Eg the details below would be shown as:
+#    Subject: C=UK, ST=Hertfordshire, L=My Town, O=Some Organisation, OU=Some Department, CN=www.example.com/emailAddress=bofh@example.com
+
+# Leave as long names as it helps documentation
+
+countryName=		UK
+stateOrProvinceName=	Midlothian
+localityName=		Edinburgh
+organizationName=	University of Edinburgh
+organizationalUnitName=	Informatics
+
+[ req_attributes ]
+# None. Could put Challenge Passwords, don't want them, leave empty
+
+[ v3_req ]
+
+# X509v3 extensions to add to a certificate request
+# See x509v3_config
+
+# What the key can/cannot be used for:
+#basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth,serverAuth
+
+# The subjectAltName is where you give the names of extra web sites.
+# You may have more than one of these, so put in the section [ alt_names ]
+# If you do not have any extra names, comment the next line out.
+#subjectAltName = @alt_names
+
+# List of all the other DNS names that the certificate should work for.
+# alt_names is a name of my own invention
+#[ alt_names ]
+#DNS.1 = devel.example.com
+#DNS.2 = ipv6.example.com
+#DNS.3 = ipv4.example.com
+#DNS.4 = test.example.com
+#DNS.5 = party.example.com
+
+[ ca ]
+default_ca = default_ca_opts
+
+[ default_ca_opts ]
+serial = ./serial
+database = ./index.txt
+new_certs_dir = .
+default_md = sha1
+default_days = 365
+# a section with a set of variables corresponding to DN fields
+policy = my_policy
+
+[ my_policy ]
+# if the value is "match" then the field value must match the same field in the
+# CA certificate. If the value is "supplied" then it must be present.
+# Optional means it may be present. Any fields not mentioned are silently
+# deleted.
+countryName = match
+stateOrProvinceName = supplied
+organizationName = supplied
+commonName = supplied
+organizationalUnitName = optional
+commonName = supplied

--- a/openssl.cnf.default
+++ b/openssl.cnf.default
@@ -1,12 +1,5 @@
-#
-# Example OpenSSL configuration file for use with Let's Encrypt.
-# This is only being used for generation of certificate requests.
-# Modified from a standard example by Parliament Hill Computers Ltd.
-#
+# File based on example available here: https://www.phcomp.co.uk/Tutorials/Web-Technologies/Understanding-and-generating-OpenSSL.cnf-files.html
 
-# This definition stops the following lines choking if HOME isn't
-# defined.
-HOME			= .
 RANDFILE		= ./.rnd
 
 [ req ]
@@ -22,18 +15,15 @@ req_extensions		= v3_req
 
 [ req_distinguished_name ]
 # Describe the Subject (ie the origanisation).
-# The first 6 below could be shortened to: C ST L O OU CN
 # The short names are what are shown when the certificate is displayed.
-# Eg the details below would be shown as:
-#    Subject: C=UK, ST=Hertfordshire, L=My Town, O=Some Organisation, OU=Some Department, CN=www.example.com/emailAddress=bofh@example.com
 
 # Leave as long names as it helps documentation
 
-countryName=		UK
-stateOrProvinceName=	Midlothian
-localityName=		Edinburgh
-organizationName=	University of Edinburgh
-organizationalUnitName=	Informatics
+countryName=            FR
+stateOrProvinceName=    PACA
+localityName=           Aix
+organizationName=       Eurecom
+organizationalUnitName= CM
 
 [ req_attributes ]
 # None. Could put Challenge Passwords, don't want them, leave empty


### PR DESCRIPTION
# Description

This pull request fixes a syntax error in `clean_oai_on_k8s` and changes `generate_certs` to use a default `openssl.cnf` if it doesn't exist.

The file `openssl.cnf.default` is filled to the best of my knowledge with sensible defaults (but I am new to OpenSSL so feedback would be welcome). The HSS and MME boot happily under certificates generated by this script on my k8s cluster.

# Motivation and Context

For my undergraduate dissertation, I'm looking at scaling the EPC on Kubernetes and so this repository has been super helpful. When I tried to deploy this repo, however, the HSS crashed because of bad certificates and this script wasn't working because my environment doesn't have a default `openssl.cnf`.

After creating a default configuration and running this script with it, my deployment all worked so I'm upstreaming this change in case it's helpful to anyone else.

For reference, my cluster is running on [POWDER](https://powderwireless.net/) and configuration can be found in [notexactlyawe/honours-project](https://github.com/notexactlyawe/honours-project). It is based off kubeadm and flannel.

# How Has This Been Tested?

 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [X] Tested locally
 - [ ] Have not tested

Types of changes

 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Checklist:

 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.